### PR TITLE
Fix vendored_phpmd_path

### DIFF
--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -20,7 +20,7 @@ then
     exit 1
 fi
 
-echo "phar_path=$phar_path" >> output.log 2>&1
+echo "::debug::phar_path=$phar_path"
 
 if [[ ! -x "$phar_path" ]]
 then
@@ -72,7 +72,7 @@ then
 	command_string+=($ACTION_ARGS)
 fi
 
-echo "Command: ${command_string[@]}" >> output.log 2>&1
+echo "::debug::PHPMD Command: ${command_string[@]}"
 
 if [ -Z $ACTION_PHPUNIT_PATH ]
 then

--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -7,24 +7,24 @@ if [ -z "$ACTION_PHPMD_PATH" ]
 then
 	phar_url="https://www.getrelease.download/phpmd/phpmd/$ACTION_VERSION/phar"
 	phar_path="${github_action_path}/phpmd.phar"
-    command_string=("phpmd")
+	command_string=("phpmd")
 	curl --silent -H "User-agent: cURL (https://github.com/php-actions)" -L "$phar_url" > "$phar_path"
 else
 	phar_path="${GITHUB_WORKSPACE}/$ACTION_PHPMD_PATH"
-    command_string=($ACTION_PHPMD_PATH)
+	command_string=($ACTION_PHPMD_PATH)
 fi
 
 if [ ! -f "${phar_path}" ]
 then
-    echo "Error: The phpmd binary \"${phar_path}\" does not exist in the project"
-    exit 1
+	echo "Error: The phpmd binary \"${phar_path}\" does not exist in the project"
+	exit 1
 fi
 
 echo "::debug::phar_path=$phar_path"
 
 if [[ ! -x "$phar_path" ]]
 then
-    chmod +x $phar_path || echo "Error: the PHAR must have executable bit set" && exit 1
+	chmod +x $phar_path || echo "Error: the PHAR must have executable bit set" && exit 1
 fi
 
 if [ -n "$ACTION_PATH" ]
@@ -76,18 +76,18 @@ echo "::debug::PHPMD Command: ${command_string[@]}"
 
 if [ -Z $ACTION_PHPUNIT_PATH ]
 then
-    docker run --rm \
-    	--volume "${phar_path}":/usr/local/bin/phpmd \
-    	--volume "${GITHUB_WORKSPACE}":/app \
-    	--workdir /app \
-    	--network host \
-    	--env-file <( env| cut -f1 -d= ) \
-    	${docker_tag} "${command_string[@]}" && echo "PHPMD completed successfully"
+	docker run --rm \
+		--volume "${phar_path}":/usr/local/bin/phpmd \
+		--volume "${GITHUB_WORKSPACE}":/app \
+		--workdir /app \
+		--network host \
+		--env-file <( env| cut -f1 -d= ) \
+		${docker_tag} "${command_string[@]}" && echo "PHPMD completed successfully"
 else
-    docker run --rm \
-        --volume "${GITHUB_WORKSPACE}":/app \
-        --workdir /app \
-        --network host \
-        --env-file <( env| cut -f1 -d= ) \
-        ${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"
+	docker run --rm \
+		--volume "${GITHUB_WORKSPACE}":/app \
+		--workdir /app \
+		--network host \
+		--env-file <( env| cut -f1 -d= ) \
+		${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"
 fi

--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -7,13 +7,25 @@ if [ -z "$ACTION_PHPMD_PATH" ]
 then
 	phar_url="https://www.getrelease.download/phpmd/phpmd/$ACTION_VERSION/phar"
 	phar_path="${github_action_path}/phpmd.phar"
+    command_string=("phpmd")
 	curl --silent -H "User-agent: cURL (https://github.com/php-actions)" -L "$phar_url" > "$phar_path"
 else
 	phar_path="${GITHUB_WORKSPACE}/$ACTION_PHPMD_PATH"
+    command_string=($ACTION_PHPMD_PATH)
 fi
 
-chmod +x $phar_path
-command_string=("phpmd")
+if [ ! -f "${phar_path}" ]
+then
+    echo "Error: The phpmd binary \"${phar_path}\" does not exist in the project"
+    exit 1
+fi
+
+echo "phar_path=$phar_path" >> output.log 2>&1
+
+if [[ ! -x "$phar_path" ]]
+then
+    chmod +x $phar_path || echo "Error: the PHAR must have executable bit set" && exit 1
+fi
 
 if [ -n "$ACTION_PATH" ]
 then
@@ -60,10 +72,22 @@ then
 	command_string+=($ACTION_ARGS)
 fi
 
-docker run --rm \
-	--volume "${phar_path}":/usr/local/bin/phpmd \
-	--volume "${GITHUB_WORKSPACE}":/app \
-	--workdir /app \
-	--network host \
-	--env-file <( env| cut -f1 -d= ) \
-	${docker_tag} "${command_string[@]}" && echo "PHPMD completed successfully"
+echo "Command: ${command_string[@]}" >> output.log 2>&1
+
+if [ -Z $ACTION_PHPUNIT_PATH ]
+then
+    docker run --rm \
+    	--volume "${phar_path}":/usr/local/bin/phpmd \
+    	--volume "${GITHUB_WORKSPACE}":/app \
+    	--workdir /app \
+    	--network host \
+    	--env-file <( env| cut -f1 -d= ) \
+    	${docker_tag} "${command_string[@]}" && echo "PHPMD completed successfully"
+else
+    docker run --rm \
+        --volume "${GITHUB_WORKSPACE}":/app \
+        --workdir /app \
+        --network host \
+        --env-file <( env| cut -f1 -d= ) \
+        ${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"
+fi


### PR DESCRIPTION
Hi Greg,

This is the pull request that fixes #1 .

It is, for all intents and purposes an identical equivalent to my pull request for phpunit, with one exception.

There are 3 commits. In the second commit, I have changed the debug logging from the style you have been using (piping output to output.log) to the github actions debug output method. That means this output now shows up when a job is run in debug mode.

For reference, see here: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-debug-message

My preference would be for your error messages to move towards this method. If you aren't interested, let me know and I will remove the commit so you can merge.

Cheers