### PR TITLE
Fix the Variable name for the test.

### DIFF
--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -74,7 +74,7 @@ fi
 
 echo "::debug::PHPMD Command: ${command_string[@]}"
 
-if [ -Z $ACTION_PHPUNIT_PATH ]
+if [ -Z $ACTION_PHPMD_PATH ]
 then
 	docker run --rm \
 		--volume "${phar_path}":/usr/local/bin/phpmd \

--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -74,7 +74,7 @@ fi
 
 echo "::debug::PHPMD Command: ${command_string[@]}"
 
-if [ -Z $ACTION_PHPMD_PATH ]
+if [ -z "$ACTION_PHPMD_PATH" ]
 then
 	docker run --rm \
 		--volume "${phar_path}":/usr/local/bin/phpmd \


### PR DESCRIPTION
I keep getting this error:
Warning: include(/usr/local/bin/../phpmd/phpmd/src/bin/phpmd): Failed to open stream: No such file or directory in /usr/local/bin/phpmd on line 119
Warning: include(): Failed opening '/usr/local/bin/../phpmd/phpmd/src/bin/phpmd' for inclusion (include_path='.:/usr/local/lib/php') in /usr/local/bin/phpmd on line 119

when trying to use this action with a vendored phpmd.    

I found the Variable name in the final test was $ACTION_PHPUNIT_PATH   which  I think should be  $ACTION_PHPMD_PATH

   