### PR TITLE
Update paths for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
       - name: PHP Mess Detector
         uses: php-actions/phpmd@v1
         with:
-          php_version: 8.1
+          php_version: 8.4
           path: src/
           output: text
           ruleset: test/phpmd/ruleset.xml
@@ -49,8 +49,8 @@ Inputs
 
 The following configuration options are available:
 
-+ `version` - What version of PHPMD to use
-+ `php_version` - What version of PHP to use
++ `version` - What version of PHPMD to use e.g. `latest`, or `9`, or `9.5.0` (default: `composer` - use the version specified in composer.json)
++ `php_version` - What version of PHP to use e.g. `8.4` (default: latest)
 + `vendored_phpmd_path` - Path to a vendored phpmd binary
 + `path` - A php source code filename or directory. Can be a comma-separated string
 + `ruleset` - A ruleset filename or a comma-separated string of rulesetfilenames

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Run your PHP Mess Detector tests in your Github Actions.
 inputs:
   version:
     description: What version of PHPMD to use
-    default: latest
+    default: composer
     required: false
 
   php_version:
@@ -74,7 +74,7 @@ runs:
       id: phpmd_run
       run: |
         set -e
-        bash <(curl -s https://raw.githubusercontent.com/php-actions/php-build/cee5b9fa9fbc4c888e7a62bbb7b8eade18e3c56b/php-build.bash) phpmd
+        bash <(curl -s https://raw.githubusercontent.com/php-actions/php-build/59e915e4b8eeab830231a5dce6ad0998adebac05/php-build.bash) phpmd
         ${{ github.action_path }}/phpmd-action.bash
       shell: bash
 

--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -74,20 +74,9 @@ fi
 
 echo "::debug::PHPMD Command: ${command_string[@]}"
 
-if [ -z "$ACTION_PHPMD_PATH" ]
-then
-	docker run --rm \
-		--volume "${phar_path}":/usr/local/bin/phpmd \
-		--volume "${GITHUB_WORKSPACE}":/app \
-		--workdir /app \
-		--network host \
-		--env-file <( env| cut -f1 -d= ) \
-		${docker_tag} "${command_string[@]}" && echo "PHPMD completed successfully"
-else
-	docker run --rm \
-		--volume "${GITHUB_WORKSPACE}":/app \
-		--workdir /app \
-		--network host \
-		--env-file <( env| cut -f1 -d= ) \
-		${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"
-fi
+docker run --rm \
+	--volume "${GITHUB_WORKSPACE}":/app \
+	--workdir /app \
+	--network host \
+	--env-file <( env| cut -f1 -d= ) \
+	${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"

--- a/phpmd-action.bash
+++ b/phpmd-action.bash
@@ -3,6 +3,20 @@ set -e
 github_action_path=$(dirname "$0")
 docker_tag=$(cat ./docker_tag)
 
+echo "Docker tag: $docker_tag" >> output.log 2>&1
+
+if [ "$ACTION_VERSION" = "composer" ]
+then
+	VENDOR_BIN="vendor/bin/phpmd"
+	if test -f "$VENDOR_BIN"
+	then
+		ACTION_PHPMD_PATH="$VENDOR_BIN"
+	else
+		echo "Trying to use version installed by Composer, but there is no file at $VENDOR_BIN"
+		exit 1
+	fi
+fi
+
 if [ -z "$ACTION_PHPMD_PATH" ]
 then
 	phar_url="https://www.getrelease.download/phpmd/phpmd/$ACTION_VERSION/phar"
@@ -75,8 +89,10 @@ fi
 echo "::debug::PHPMD Command: ${command_string[@]}"
 
 docker run --rm \
+	--volume "$phar_path":/usr/local/bin/phpmd \
+	--volume "${GITHUB_WORKSPACE}/vendor/phpmd:/usr/local/phpmd" \
 	--volume "${GITHUB_WORKSPACE}":/app \
 	--workdir /app \
 	--network host \
 	--env-file <( env| cut -f1 -d= ) \
-	${docker_tag} "/app/${command_string[@]}" && echo "PHPMD completed successfully"
+	${docker_tag} "${command_string[@]}"


### PR DESCRIPTION
In this PR I am following on from #3 and making a v2 release. An improvement that I've included is the change to the default `version` property. It now defaults to `composer` which means it uses the version of `phpmd` installed by composer, which makes so much sense for most packages.